### PR TITLE
metacritic plugin

### DIFF
--- a/plugins/metacritic.py
+++ b/plugins/metacritic.py
@@ -1,4 +1,4 @@
-#Metacritic.com scraper
+# metacritic.com scraper
 
 from util import hook, http
 
@@ -11,6 +11,8 @@ def metacritic(inp):
     '.mc [all|movie|tv|album|x360|ps3|pc|ds|wii] <title> -- gets rating for'\
     ' <title> from metacritic on the specified medium'
 
+    # if the results suck, it's metacritic's fault
+
     args = inp.strip()
 
     game_platforms = ('x360', 'ps3', 'pc', 'ds', 'wii', '3ds', 'gba')
@@ -19,6 +21,9 @@ def metacritic(inp):
     try:
         plat, title = args.split(' ', 1)
         if plat not in all_platforms:
+            # raise the ValueError so that the except block catches it
+            # in this case, or in the case of the .split above raising the
+            # ValueError, we want the same thing to happen
             raise ValueError
     except ValueError:
         plat = 'all'


### PR DESCRIPTION
This plugin scrapes the metacritic search results page for the title you're searching for and returns the platform, title, metascore, release date and link.

The plugin accepts a category and a title. The category is optional and defaults to 'all'

Example session:

```
   User | .mc x360 Dragon Age II
skybot | User: [X360] Dragon Age II - no score, release: Mar 8, 2011 -- http://metacritic.com/game/xbox-360/dragon-age-ii
   User | .mc The Simpsons
skybot | User: [TV SHOW] The Simpsons - no score, release: Dec 17, 1989 -- http://metacritic.com/tv/the-simpsons
   User | .mc Diablo II
skybot | User: [PC] Diablo II - 88, release: Jun 29, 2000 -- http://metacritic.com/game/pc/diablo-ii
   User | .mc fart
skybot | User: [TV SHOW] The Animals of Farthing Wood - no score, release: Jan 1, 1993 -- http://metacritic.com/tv/the-animals-of-farthing-wood
```
