### PR TITLE
Wolfram Alpha plugin spacing issue

### DIFF
--- a/plugins/wolframalpha.py
+++ b/plugins/wolframalpha.py
@@ -7,7 +7,7 @@ from util import hook, http
 @hook.command
 def wolframalpha(inp):
     ".wa/.wolframalpha <query> -- scrapes Wolfram Alpha's" \
-            "results for <query>"
+            " results for <query>"
 
     url = "http://www.wolframalpha.com/input/?asynchronous=false"
 


### PR DESCRIPTION
The Wolfram Alpha plugin is missing a space in the docstring. This is a single commit that fixes that.

`<skybot> avidal: .wa/.wolframalpha <query> -- scrapes Wolfram Alpha'sresults for <query>`
