### PR TITLE
Fixed path lowercasing bug in logging plugin.

### DIFF
--- a/plugins/log.py
+++ b/plugins/log.py
@@ -32,7 +32,7 @@ irc_color_re = re.compile(r'(\x03(\d+,\d+|\d)|[\x0f\x02\x16\x1f])')
 
 def get_log_filename(dir, server, chan):
     return os.path.join(dir, 'log', gmtime('%Y'), server,
-            gmtime('%%s.%m-%d.log') % chan).lower()
+            (gmtime('%%s.%m-%d.log') % chan).lower())
 
 
 def gmtime(format):


### PR DESCRIPTION
Previously, the entire path would be lowercased, which breaks instances where one of the parents of the working directory have capital letters. Now, it only lowercases the actual log filename, not the path.
