### PR TITLE
Fix @hook.singlethread when the hook throws

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -102,7 +102,10 @@ class Handler(object):
                     db_conns[input.conn] = db
                 input.db = db
 
-            run(self.func, input)
+            try:
+                run(self.func, input)
+            except:
+                traceback.print_exc()
 
     def stop(self):
         self.input_queue.put(StopIteration)


### PR DESCRIPTION
Tested against buttebot, this PR makes sure that if a single-threaded hook throws, it won't totally kill the hook.
