### PR TITLE
Fixes the broken .bitcoin command

### DIFF
--- a/plugins/bitcoin.py
+++ b/plugins/bitcoin.py
@@ -4,7 +4,13 @@ from util import http, hook
 @hook.command(autohelp=False)
 def bitcoin(inp, say=None):
     ".bitcoin -- gets current exchange rate for bitcoins from mtgox"
-    data = http.get_json("https://mtgox.com/code/data/ticker.php")
-    ticker = data['ticker']
-    say("Current: \x0307$%(buy).2f\x0f - High: \x0307$%(high).2f\x0f"
-        " - Low: \x0307$%(low).2f\x0f - Volume: %(vol)s" % ticker)
+    data = http.get_json("https://data.mtgox.com/api/2/BTCUSD/money/ticker")
+    data = data['data']
+    ticker = {
+        'buy': data['buy']['display_short'],
+        'high': data['high']['display_short'],
+        'low': data['low']['display_short'],
+        'vol': data['vol']['display_short'],
+    }
+    say("Current: \x0307%(buy)s\x0f - High: \x0307%(high)s\x0f"
+        " - Low: \x0307%(low)s\x0f - Volume: %(vol)s" % ticker)


### PR DESCRIPTION
This fixes the broken .bitcoin command by updating to the latest MtGox API.
