### PR TITLE
Fix command execution through Tweets

### DIFF
--- a/plugins/twitter.py
+++ b/plugins/twitter.py
@@ -47,7 +47,7 @@ def twitter(inp, api_key=None):
     screen_name = tweet["user"]["screen_name"]
     time = tweet["created_at"]
 
-    text = unescape(text, {'&apos;': "'", "&quot;": '"'})
+    text = unescape(text, {'&apos;': "'", "&quot;": '"'}).replace('\n', ' ')
     time = strftime('%Y-%m-%d %H:%M:%S', strptime(time, '%a %b %d %H:%M:%S +0000 %Y'))
 
     return "%s %s: %s" % (time, screen_name, text)


### PR DESCRIPTION
If a Tweet contains a new line it will be sent as a separate message to the IRC server, allowing the execution of any IRC commands.
