### PR TITLE
Added GIF search plugin

### DIFF
--- a/plugins/gif.py
+++ b/plugins/gif.py
@@ -1,3 +1,5 @@
+import random
+
 from util import hook, http
 
 
@@ -8,12 +10,12 @@ def giphy(inp, api_key=None):
     '''.gif/.giphy <query> -- returns first giphy search result'''
     url = 'http://api.giphy.com/v1/gifs/search'
     try:
-        response = http.get_json(url, q=inp, limit=1, api_key=api_key)
+        response = http.get_json(url, q=inp, limit=10, api_key=api_key)
     except http.HTTPError as e:
         return e.msg
 
     results = response.get('data')
     if results:
-        return results[0].get('bitly_gif_url')
+        return random.choice(results).get('bitly_gif_url')
     else:
         return 'no results found'


### PR DESCRIPTION
This is basically similar to the Google Image Search command, but uses the [Giphy API](https://github.com/giphy/GiphyAPI) to return a random GIF in the top ten results for a given query.

The API is currently in beta, and has a single public API key `dc6zaTOxFJmzC` that will need to be added to the `api_keys` config setting:

``` json
{"api_keys": {"giphy": "dc6zaTOxFJmzC"}}
```

If this ends up being heavily used, it is recommended to contact api@giphy.com for a unique API key.
