### PR TITLE
Feature http headers

### DIFF
--- a/plugins/dictionary.py
+++ b/plugins/dictionary.py
@@ -9,7 +9,7 @@ def urban(inp):
     '''.u/.urban <phrase> -- looks up <phrase> on urbandictionary.com'''
 
     url = 'http://www.urbandictionary.com/iphone/search/define'
-    page = http.get_json(url, term=inp, referer="http://m.urbandictionary.com")
+    page = http.get_json(url, term=inp, headers={'Referer': 'http://m.urbandictionary.com'})
     defs = page['list']
 
     if page['result_type'] == 'no_results':

--- a/plugins/util/http.py
+++ b/plugins/util/http.py
@@ -20,7 +20,7 @@ from lxml import etree, html
 ua_skybot = 'Skybot/1.0 http://github.com/rmmh/skybot'
 
 ua_firefox = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.6) ' \
-    'Gecko/20070725 Firefox/2.0.0.6'
+             'Gecko/20070725 Firefox/2.0.0.6'
 ua_internetexplorer = 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)'
 
 jar = cookielib.CookieJar()
@@ -42,14 +42,10 @@ def get_json(*args, **kwargs):
     return json.loads(get(*args, **kwargs))
 
 
-def open(url, query_params=None, user_agent=None, referer=None, post_data=None,
-         get_method=None, cookies=False, oauth=False, oauth_keys=None, **kwargs):
-
+def open(url, query_params=None, post_data=None,
+         get_method=None, cookies=False, oauth=False, oauth_keys=None, headers=None, **kwargs):
     if query_params is None:
         query_params = {}
-
-    if user_agent is None:
-        user_agent = ua_skybot
 
     query_params.update(kwargs)
 
@@ -60,10 +56,12 @@ def open(url, query_params=None, user_agent=None, referer=None, post_data=None,
     if get_method is not None:
         request.get_method = lambda: get_method
 
-    request.add_header('User-Agent', user_agent)
+    if headers is not None:
+        for header_key, header_value in headers.iteritems():
+            request.add_header(header_key, header_value)
 
-    if referer is not None:
-        request.add_header('Referer', referer)
+    if 'User-Agent' not in request.headers:
+        request.add_header('User-Agent', ua_skybot)
 
     if oauth:
         nonce = oauth_nonce()
@@ -73,7 +71,7 @@ def open(url, query_params=None, user_agent=None, referer=None, post_data=None,
             nonce, timestamp, req_data, oauth_keys['consumer'], oauth_keys['access'])
 
         signature = oauth_sign_request("GET", api_url, req_data, unsigned_request, oauth_keys[
-                                       'consumer_secret'], oauth_keys['access_secret'])
+            'consumer_secret'], oauth_keys['access_secret'])
 
         header = oauth_build_header(
             nonce, signature, timestamp, oauth_keys['consumer'], oauth_keys['access'])


### PR DESCRIPTION
Removes the `referer` and `user_agent` parameters from `http.open()` in favor of a dictionary of headers, allowing plugins to add their own headers if necessary
