### PR TITLE
Addition of !rollgroups command and !dnd3d6 commands to dice.py.

### DIFF
--- a/plugins/dice.py
+++ b/plugins/dice.py
@@ -37,7 +37,7 @@ def nrolls(count, n):
 @hook.command
 def dice(inp):
     ".dice <diceroll> -- simulates dicerolls, e.g. .dice 2d20-d5+4 roll 2 " \
-        "D20s, subtract 1D5, add 4"
+        "D20s, subtract 1D5, add 4  - Thomson Comer Edition"
 
     try:  # if inp is a re.match object...
         (inp, desc) = inp.groups()
@@ -126,5 +126,6 @@ def groups(inp):
 @hook.command('dnd3d6')
 @hook.command
 def dnd3d6():
+    ' returns an OD&D 3d6 character rollup '
     return groups("6#3d6")
 

--- a/plugins/dice.py
+++ b/plugins/dice.py
@@ -37,7 +37,7 @@ def nrolls(count, n):
 @hook.command
 def dice(inp):
     ".dice <diceroll> -- simulates dicerolls, e.g. .dice 2d20-d5+4 roll 2 " \
-        "D20s, subtract 1D5, add 4  - Thomson Comer Edition"
+        "D20s, subtract 1D5, add 4"
 
     try:  # if inp is a re.match object...
         (inp, desc) = inp.groups()
@@ -90,7 +90,8 @@ def dice(inp):
 
 @hook.command('rollgroups')
 def groups(inp):
-    ".groups <n#<diceroll>> -- allows execution of a set of dice rolls"
+    ".groups <n[v]#<diceroll>> -- allows execution of a set of dice rolls " \
+        "returning the result of each set"
     if '#' in inp:
       times, roll = inp.split('#')
     else:
@@ -136,6 +137,6 @@ def groups(inp):
 
 @hook.command('dnd3d6')
 def dnd3d6(inp):
-    ' returns an OD&D 3d6 character rollup '
+    'returns an OD&D 3d6 character rollup'
     return groups("6#3d6")
 

--- a/plugins/dice.py
+++ b/plugins/dice.py
@@ -87,3 +87,44 @@ def dice(inp):
         return "%s: %d (%s=%s)" % (desc.strip(),  total, inp, ", ".join(rolls))
     else:
         return "%d (%s=%s)" % (total, inp, ", ".join(rolls))
+
+@hook.command('rollgroups')
+@hook.command
+def groups(inp):
+    ".groups <n#<diceroll>> -- allows execution of a set of dice rolls"
+    times, roll = inp.split('#')
+
+    verbose = False
+    if 'v' in times:
+        verbose = True
+
+    times = times.replace('v','')
+
+    try:
+        (inp, desc) = roll.groups()
+    except AttributeError:
+        (inp, desc) = valid_diceroll_re.match(roll).groups()
+
+    results = []
+    rolls = []
+    for i in range(int(times)):
+        result = dice(inp)
+        results.append(result.split()[0])
+        result = result.replace(')', '')
+        result_rhs = result.split('=')[1]
+        result_rolls = result_rhs.split(',')
+        rolls.append(' '.join(result_rolls)) 
+
+    if not verbose:
+        rolls = ''
+
+    if desc:
+      return desc + ": %s (%s) %s" % (inp, ' '.join(results), rolls)
+    else:
+        return "%s (%s) %s" % (inp, ' '.join(results), rolls)
+
+@hook.command('dnd3d6')
+@hook.command
+def dnd3d6():
+    return groups("6#3d6")
+

--- a/plugins/dice.py
+++ b/plugins/dice.py
@@ -89,7 +89,6 @@ def dice(inp):
         return "%d (%s=%s)" % (total, inp, ", ".join(rolls))
 
 @hook.command('rollgroups')
-@hook.command
 def groups(inp):
     ".groups <n#<diceroll>> -- allows execution of a set of dice rolls"
     times, roll = inp.split('#')
@@ -124,8 +123,7 @@ def groups(inp):
         return "%s (%s) %s" % (inp, ' '.join(results), rolls)
 
 @hook.command('dnd3d6')
-@hook.command
-def dnd3d6():
+def dnd3d6(inp):
     ' returns an OD&D 3d6 character rollup '
     return groups("6#3d6")
 

--- a/plugins/dice.py
+++ b/plugins/dice.py
@@ -91,21 +91,33 @@ def dice(inp):
 @hook.command('rollgroups')
 def groups(inp):
     ".groups <n#<diceroll>> -- allows execution of a set of dice rolls"
-    times, roll = inp.split('#')
+    if '#' in inp:
+      times, roll = inp.split('#')
+    else:
+      times, roll = ('1',inp)
 
     verbose = False
     if 'v' in times:
         verbose = True
-
     times = times.replace('v','')
 
     try:
         (inp, desc) = roll.groups()
     except AttributeError:
-        (inp, desc) = valid_diceroll_re.match(roll).groups()
+        dice_roll = valid_diceroll_re.match(roll)
+        if dice_roll:
+          (inp, desc) = valid_diceroll_re.match(roll).groups()
+        else:
+          return "Bad dice roll syntax - %".format(roll)
 
     results = []
     rolls = []
+
+    try:
+      times = int(times)
+    except ValueError:
+      return "Bad dice roll syntax = %".format(roll)
+
     for i in range(int(times)):
         result = dice(inp)
         results.append(result.split()[0])

--- a/plugins/dice_test.py
+++ b/plugins/dice_test.py
@@ -1,0 +1,38 @@
+import dice
+
+import re
+import nose
+from sys import argv
+
+def get_from_parens(return_string):
+  parens = re.compile("\((.+)\)")
+  result = parens.search(return_string)
+  return result.group(1)
+
+def test_1d6():
+  roll = dice.groups("1d6")
+  result = get_from_parens(roll)
+  assert int(result) in range(1,7)
+
+def test_2_1d6():
+  roll = dice.groups("2#1d6")
+  result = get_from_parens(roll)
+  x, y = result.split()
+  assert int(x) in range(1,7)
+  assert int(y) in range(1,7)
+
+def test_a_1d6():
+  roll = dice.groups("a#1d6")
+  assert 'Bad' in roll
+
+def test_1_aaa():
+  roll = dice.groups("1#aaa")
+  assert 'Bad' in roll
+
+def test_garbage():
+  roll = dice.groups("as@#5a%4!!7.>f")
+  assert 'Bad' in roll
+
+def main():
+  print(dice.groups(roll))
+  roll = argv[1]

--- a/plugins/dice_test.py
+++ b/plugins/dice_test.py
@@ -4,6 +4,11 @@ import re
 import nose
 from sys import argv
 
+""" Tests for Thomson Comer's additions to the dice.py plugin.
+    Run with nosetests dice_test.py.  Can also be run interactively
+    using python dice_test.py <rollstring>
+"""
+
 def get_from_parens(return_string):
   parens = re.compile("\((.+)\)")
   result = parens.search(return_string)
@@ -36,3 +41,4 @@ def test_garbage():
 def main():
   print(dice.groups(roll))
   roll = argv[1]
+


### PR DESCRIPTION
I made a simple X#YdZ syntax for making repeats of the desired dice roll.  Useful for rolling up characters in an RPG, or getting quick and unmessy results for a long sequence of identical actions.

Unit tests for my additions in dice_test.py, runnable via nosetests.
