### PR TITLE
Properly handle multicharacter bot prefixes

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -175,10 +175,10 @@ def main(conn, out):
     if inp.command == 'PRIVMSG':
         # COMMANDS
         bot_prefix = re.escape(bot.config.get("prefix", "."))
-        if inp.chan == inp.nick:  # private message, no command prefix
-            prefix = r'^(?:['+bot_prefix+']?|'
+        if inp.chan == inp.nick:  # private message, no command prefix required
+            prefix = r'^(?:(?:'+bot_prefix+')?|'
         else:
-            prefix = r'^(?:['+bot_prefix+']|'
+            prefix = r'^(?:'+bot_prefix+'|'
 
         command_re = prefix + inp.conn.nick
         command_re += r'[:,]+\s+)(\w+)(?:$|\s+)(.*)'


### PR DESCRIPTION
Right now because of the brackets around the bot prefix, it's treating the whole bot prefix string as a set of different possible one-character prefixes.
