### PR TITLE
allow override of sieve's ignorebots in config

### DIFF
--- a/plugins/sieve.py
+++ b/plugins/sieve.py
@@ -6,6 +6,7 @@ from util import hook
 @hook.sieve
 def sieve_suite(bot, input, func, kind, args):
     if input.command == 'PRIVMSG' and \
+       bot.config.get('ignorebots', True) and \
        input.nick.lower()[-3:] == 'bot' and args.get('ignorebots', True):
             return None
 


### PR DESCRIPTION
sometimes users want their bots to harrass skybot.  or other users may have their name end in bot.

this configuration option helps.
