### PR TITLE
Don't include " dontsave" when displaying weather API failures

### DIFF
--- a/plugins/weather.py
+++ b/plugins/weather.py
@@ -22,11 +22,12 @@ def weather(inp, chan='', nick='', reply=None, db=None, api_key=None):
         loc = None
         dontsave = True
     else:
-        loc = inp
-
-        dontsave = loc.endswith(" dontsave")
+        dontsave = inp.endswith(" dontsave")
+        # strip off the " dontsave" text if it exists and set it back to `inp` so we don't report it
+        # back to the user incorrectly
         if dontsave:
-            loc = loc[:-9].strip().lower()
+            inp = inp[:-9].strip().lower()
+        loc = inp
 
     if not loc:  # blank line
         loc = db.execute(


### PR DESCRIPTION
The weather plugin will reply with "Could not find weather for <input>" when the API response doesn't include the "current_observation" key. However, when the user appends " dontsave" to the query that gets reported back to the user and confuses the shit out of everyone.