### PR TITLE
Prevent ssl disconnects

### DIFF
--- a/core/irc.py
+++ b/core/irc.py
@@ -114,9 +114,6 @@ class crlf_ssl_tcp(crlf_tcp):
         return SSLError
 
     def handle_receive_exception(self, error, last_timestamp):
-        # this is terrible
-        if not "timed out" in error.args[0]:
-            raise
         return crlf_tcp.handle_receive_exception(self, error, last_timestamp)
 
 irc_prefix_rem = re.compile(r'(.*?) (.*?) (.*)').match


### PR DESCRIPTION
The self described hack doesn't seem to work in python 2.7, and I'm not sure it's intended purpose. Whenever it gets hit, I get the error 'TypeError: argument of type 'int' is not iterable' and skybot stops working.

I've removed it here and have had continuous uptime against an ssl irc connection for a couple of weeks.

If you can let me know the removed code's intended use, I can try fixing the original problem in a better way.