### PR TITLE
Use soft-link-safe chdir

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,7 +19,7 @@ bot = Bot()
 def main():
     sys.path += ['plugins']  # so 'import hook' works without duplication
     sys.path += ['lib']
-    os.chdir(sys.path[0] or '.')  # do stuff relative to the install directory
+    os.chdir(os.path.dirname(__file__) or '.')  # do stuff relative to the install directory
 
     print 'Loading plugins'
 


### PR DESCRIPTION
Basically to ease maintenance and reduce issues, I make soft links for relevant folders and files (`bot.py`, `core/` and `plugins/util/`) in a different folder and then use `./bot.py` to run it. This way I can have several different bots running different plugins, and update them all executing a single `git pull` on the original clean source folder.

`sys.path[0]` apparently refers to real file rather than link file, so it was accessing the original plugins folder. With this change it will use the path relative to the name as executed by Python. It's exactly the same if you're using a folder of skybot per bot.