### PR TITLE
Added optional replies using NOTICE

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -18,6 +18,10 @@ class Input(dict):
             conn.msg(chan, msg)
 
         def reply(msg):
+            if self.reply_notice:
+                self.notice(msg)
+                return
+
             if chan == nick:  # PMs don't need prefixes
                 self.say(msg)
             else:
@@ -145,6 +149,8 @@ def dispatch(input, kind, func, args, autohelp=False):
             input.reply('error: missing api key')
             return
         input.api_key = key
+
+    input.reply_notice = args.get('notice', False)
 
     if func._thread:
         bot.threads[func].put(input)


### PR DESCRIPTION
Eases replies using NOTICEs by adding a new argument to @hook.command:
`@hook.command(notice=True)`

By default it won't, so it's backwards-compatible.