### PR TITLE
Paged remembers tweaks

### DIFF
--- a/plugins/remember.py
+++ b/plugins/remember.py
@@ -150,7 +150,7 @@ class MemoryTest(unittest.TestCase):
 
     def question(self, inp, chan='#test'):
         output = []
-        question(re.match(r'(.*)', inp),
+        question(re.match(r'(\S+) ?(\d+)?', inp),
                  chan=chan, say=output.append, db=self.db)
         return output[0] if output else None
 

--- a/plugins/remember.py
+++ b/plugins/remember.py
@@ -119,15 +119,11 @@ def get_page(data, start_idx, min_page_len, max_page_len):
 
 def get_pages(data, min_page_len, max_page_len):
     result = []
-    last_idx = 0
 
-    while True:
-        page_data, last_idx = get_page(data, last_idx, min_page_len, max_page_len)
-
-        if page_data == '':
-            break
-
+    page_data, last_idx = get_page(data, 0, min_page_len, max_page_len)
+    while page_data != '':
         result.append(page_data)
+        page_data, last_idx = get_page(data, last_idx, min_page_len, max_page_len)
 
     return result
 

--- a/plugins/remember.py
+++ b/plugins/remember.py
@@ -5,7 +5,6 @@ remember.py: written by Scaevolus 2010
 import re
 import string
 import unittest
-from math import ceil
 
 from util import hook
 

--- a/plugins/remember.py
+++ b/plugins/remember.py
@@ -118,8 +118,7 @@ def get_page(data, start_idx, min_page_len, max_page_len):
 
 
 def get_pages(data, min_page_len, max_page_len):
-    result = {}
-    i = 0
+    result = []
     last_idx = 0
 
     while True:
@@ -128,8 +127,7 @@ def get_pages(data, min_page_len, max_page_len):
         if page_data == "":
             break
 
-        result[i] = page_data
-        i += 1
+        result.append(page_data)
 
     return result
 
@@ -155,12 +153,12 @@ def question(inp, chan='', say=None, db=None):
     if data:
         pages = get_pages(data, min_page_len, message_len_limit)
         page_idx = page - 1 # 1-indexed
-        page_data = pages.get(page_idx)
-
-        if page_data is None:
+        try:
+            page_data = pages[page_idx]
+        except IndexError:
             return
 
-        last_page = max(pages.keys())
+        last_page = len(pages) - 1
         if page_idx == last_page:
             say(page_data)
             return
@@ -256,10 +254,10 @@ class MemoryTest(unittest.TestCase):
 
 
     def test_get_pages(self):
-        assert get_pages("123456789", 5, 8) == {0: "12345678", 1: "9"}
-        assert get_pages("123,456789", 5, 8) == {0: "123,4567", 1: "89"}
-        assert get_pages("123,45,67,89", 5, 8) == {0: "123,45", 1: ",67,89"}
-        assert get_pages("", 5, 8) == {}
+        assert get_pages("123456789", 5, 8) == ["12345678", "9"]
+        assert get_pages("123,456789", 5, 8) == ["123,4567", "89"]
+        assert get_pages("123,45,67,89", 5, 8) == ["123,45", ",67,89"]
+        assert get_pages("", 5, 8) == []
 
     def test_paging_message(self):
         long_string = "long "

--- a/plugins/remember.py
+++ b/plugins/remember.py
@@ -124,7 +124,7 @@ def get_pages(data, min_page_len, max_page_len):
     while True:
         page_data, last_idx = get_page(data, last_idx, min_page_len, max_page_len)
 
-        if page_data == "":
+        if page_data == '':
             break
 
         result.append(page_data)
@@ -137,7 +137,7 @@ def question(inp, chan='', say=None, db=None):
     "?<word> <page?>-- shows what data is associated with word"
     db_init(db)
 
-    more_message = " (%s page(s) left)"
+    more_message = ' (%s page(s) left)'
     message_len_limit = 512 - len(more_message) - 75 # fudge factor for protocol overhead
     min_page_len = 100
 
@@ -242,27 +242,27 @@ class MemoryTest(unittest.TestCase):
         assert "don't know" in self.forget('fakekey')
 
     def test_get_page(self):
-        assert get_page("123456789", 0, 5, 8) == ("12345678", 8) # max length
-        assert get_page("123,456789", 0, 5, 8) == ("123,4567", 8) # min length not satisfied
-        assert get_page("123,45,67,89", 0, 5, 8) == ("123,45", 6) # chooses correct comma
-        assert get_page("", 0, 5, 8) == ("", 0) # correct empty result
+        assert get_page('123456789', 0, 5, 8) == ('12345678', 8) # max length
+        assert get_page('123,456789', 0, 5, 8) == ('123,4567', 8) # min length not satisfied
+        assert get_page('123,45,67,89', 0, 5, 8) == ('123,45', 6) # chooses correct comma
+        assert get_page('', 0, 5, 8) == ('', 0) # correct empty result
         # start offsets
-        assert get_page("123456789", 1, 5, 9) == ("23456789", 9)
-        assert get_page("123456789", 1, 5, 8) == ("23456789", 9)
-        assert get_page("1234567,89", 1, 5, 8) == ("234567", 7)
-        assert get_page("", 1, 5, 8) == ("", 1)
+        assert get_page('123456789', 1, 5, 9) == ('23456789', 9)
+        assert get_page('123456789', 1, 5, 8) == ('23456789', 9)
+        assert get_page('1234567,89', 1, 5, 8) == ('234567', 7)
+        assert get_page('', 1, 5, 8) == ('', 1)
 
 
     def test_get_pages(self):
-        assert get_pages("123456789", 5, 8) == ["12345678", "9"]
-        assert get_pages("123,456789", 5, 8) == ["123,4567", "89"]
-        assert get_pages("123,45,67,89", 5, 8) == ["123,45", ",67,89"]
-        assert get_pages("", 5, 8) == []
+        assert get_pages('123456789', 5, 8) == ['12345678', '9']
+        assert get_pages('123,456789', 5, 8) == ['123,4567', '89']
+        assert get_pages('123,45,67,89', 5, 8) == ['123,45', ',67,89']
+        assert get_pages('', 5, 8) == []
 
     def test_paging_message(self):
-        long_string = "long "
+        long_string = 'long '
         for _ in range(0, 1000):
-            long_string += "a"
+            long_string += 'a'
 
         self.remember(long_string, chan='#long')
         assert '2' in self.question('long', chan='#long') # "2 pages left"
@@ -270,22 +270,22 @@ class MemoryTest(unittest.TestCase):
         assert not re.match(r'\d', self.question('long 3', chan='#long'))
 
     def test_paging_result(self):
-        long_string = "long "
+        long_string = 'long '
         for _ in range(0, 300):
-            long_string += "x"
+            long_string += 'x'
         for _ in range(0, 300):
-            long_string += "y"
+            long_string += 'y'
         for _ in range(0, 300):
-            long_string += "z"
+            long_string += 'z'
 
         self.remember(long_string, chan='#long')
         p1_data = self.question('long', chan='#long')
         p2_data = self.question('long 2', chan='#long')
         p3_data = self.question('long 3', chan='#long')
 
-        count_x = p1_data.count("x") + p2_data.count("x") + p3_data.count("x")
-        count_y = p1_data.count("y") + p2_data.count("y") + p3_data.count("y")
-        count_z = p1_data.count("z") + p2_data.count("z") + p3_data.count("z")
+        count_x = p1_data.count('x') + p2_data.count('x') + p3_data.count('x')
+        count_y = p1_data.count('y') + p2_data.count('y') + p3_data.count('y')
+        count_z = p1_data.count('z') + p2_data.count('z') + p3_data.count('z')
 
         # no data lost
         assert count_x == 300

--- a/plugins/remember.py
+++ b/plugins/remember.py
@@ -112,6 +112,10 @@ def get_page(data, start_idx, min_page_len, max_page_len):
     returns a tuple of (result str, slice index)
     """
     page_data = data[start_idx:start_idx + max_page_len]
+
+    if len(page_data) < max_page_len:
+        return page_data, len(page_data) + start_idx
+
     last_comma_idx = page_data.rfind(',')
 
     if last_comma_idx < min_page_len:
@@ -159,6 +163,8 @@ def question(inp, chan='', say=None, db=None):
         except IndexError:
             say(page_missing_message % (word, len(pages)))
             return
+
+        page_data = page_data.lstrip(', ')
 
         last_page = len(pages) - 1
         if page_idx == last_page:
@@ -290,6 +296,17 @@ class MemoryTest(unittest.TestCase):
 
         assert page_missing_message % ('thing', 1) in self.question('thing 2')
         assert page_missing_message % ('long', 3) in self.question('long 11')
+
+    def test_strip_leading_comma(self):
+        long_string = 'long ' + 'x' * (message_len_limit - 10) + ', ' + 'y' * (message_len_limit - 10)
+        self.remember(long_string)
+        assert ', ' not in self.question('long 2')
+
+    def test_regressions(self):
+        # improper split on last comma even though full message is < length limit
+        gmg = 'gmg good morning goons, goatse morning goons, gob morning goons, good moring Gobiner, good morning gobs, goom morgan goobs'
+        self.remember(gmg)
+        assert self.question(gmg) == gmg
 
 if __name__ == '__main__':
     unittest.main()

--- a/plugins/remember.py
+++ b/plugins/remember.py
@@ -106,6 +106,12 @@ def forget(inp, chan='', db=None):
 
 
 def get_page(data, start_idx, min_page_len, max_page_len):
+    """
+    slices the data string, starting at start_idx, into a chunk no longer
+    than max_page_len. The slice will occur at a comma if the resulting
+    string would not be shorter than min_page_len.
+    returns a tuple of (result str, slice index)
+    """
     page_data = data[start_idx:start_idx + max_page_len]
     last_comma_idx = page_data.rfind(',')
 
@@ -118,6 +124,7 @@ def get_page(data, start_idx, min_page_len, max_page_len):
 
 
 def get_pages(data, min_page_len, max_page_len):
+    "slices the data string into pages using get_page, returning a list"
     result = []
 
     page_data, last_idx = get_page(data, 0, min_page_len, max_page_len)
@@ -132,7 +139,7 @@ page_missing_message = "%s only has %s page(s)"
 
 @hook.regex(r'^\? ?(\S+) ?(\d+)?')
 def question(inp, chan='', say=None, db=None):
-    "?<word> <page?>-- shows what data is associated with word"
+    "?<word> <page?>-- shows what data is associated with word, paginated by page (1 if omitted)"
     db_init(db)
 
     message_len_limit = 512 - len(more_pages_message) - 75 # fudge factor for protocol overhead

--- a/plugins/remember.py
+++ b/plugins/remember.py
@@ -140,7 +140,7 @@ message_len_limit = 512 - len(more_pages_message) - 75 # fudge factor for protoc
 
 @hook.regex(r'^\? ?(\S+) ?(\d+)?')
 def question(inp, chan='', say=None, db=None):
-    "?<word> page] -- shows what data is associated with word, paginated by page (default 1)"
+    "?<word> [page] -- shows what data is associated with word, paginated by page (default 1)"
     db_init(db)
 
     min_page_len = 100


### PR DESCRIPTION
two things so far:

* strips leading commas and spaces, so pages after 1 don't look like ", the thing"
* fixes bug where messages that were < message_len_limit would still be split on the last comma