### PR TITLE
Remove "Result:" prefix from wolfram alpha results

### DIFF
--- a/plugins/wolframalpha.py
+++ b/plugins/wolframalpha.py
@@ -15,7 +15,7 @@ def wolframalpha(inp, api_key=None):
 
     pod_texts = []
     for pod in result.xpath("//pod"):
-        title = pod.attrib['title']
+        title = '' if pod.attrib['title'] == 'Result' else pod.attrib['title'] + ': ' 
         if pod.attrib['id'] == 'Input':
             continue
 
@@ -26,7 +26,7 @@ def wolframalpha(inp, api_key=None):
             if subpod:
                 results.append(subpod)
         if results:
-            pod_texts.append(title + ': ' + '|'.join(results))
+            pod_texts.append(title + '|'.join(results))
 
     ret = '. '.join(pod_texts)
 
@@ -47,4 +47,4 @@ def wolframalpha(inp, api_key=None):
     if not ret:
         return 'no results'
 
-    return ret.replace('Result: ', '', 1)
+    return ret

--- a/plugins/wolframalpha.py
+++ b/plugins/wolframalpha.py
@@ -47,4 +47,4 @@ def wolframalpha(inp, api_key=None):
     if not ret:
         return 'no results'
 
-    return ret
+    return ret.replace('Result: ', '', 1)


### PR DESCRIPTION
We know it's the results, because it's the answer to your query