### PR TITLE
switch the drama plugin to use the .rs domain

### DIFF
--- a/plugins/drama.py
+++ b/plugins/drama.py
@@ -3,8 +3,8 @@ article'''
 
 from util import hook, http
 
-api_url = "http://encyclopediadramatica.se/api.php?action=opensearch"
-ed_url = "http://encyclopediadramatica.se/"
+api_url = "http://encyclopediadramatica.rs/api.php"
+ed_url = "http://encyclopediadramatica.rs/"
 
 
 @hook.command('ed')
@@ -13,7 +13,7 @@ def drama(inp):
     '''.drama <phrase> -- gets first paragraph of Encyclopedia Dramatica ''' \
         '''article on <phrase>'''
 
-    j = http.get_json(api_url, search=inp)
+    j = http.get_json(api_url, action="opensearch", search=inp)
     if not j[1]:
         return 'no results found'
     article_name = j[1][0].replace(' ', '_').encode('utf8')
@@ -21,7 +21,7 @@ def drama(inp):
     url = ed_url + http.quote(article_name, '')
     page = http.get_html(url)
 
-    for p in page.xpath('//div[@id="bodyContent"]/p'):
+    for p in page.xpath('//div[@id="bodyContent"]//p'):
         if p.text_content():
             summary = ' '.join(p.text_content().splitlines())
             if len(summary) > 300:


### PR DESCRIPTION
for some reason people like this plugin, but the .se
website went down a while back.  this updates the plugin to
use the new "encyclopediadramatica.rs" domain, and also
handles some changes to the HTML