### PR TITLE
use new W3C HTML Validator

### DIFF
--- a/plugins/validate.py
+++ b/plugins/validate.py
@@ -7,19 +7,39 @@ by Vladi
 from util import hook, http
 
 
+VALIDATOR_URL = 'http://validator.w3.org/nu/'
+
+
+def get_validation_results(url):
+    document = http.get_html(VALIDATOR_URL, doc=url)
+
+    results = document.xpath('//div[@id="results"]/ol')
+
+    if not results:
+        return None
+
+    results = results[0]
+
+    warnings = results.xpath('//li[contains(@class, "warning")]')
+    errors = results.xpath('//li[contains(@class, "error")]')
+
+    return {
+        'warning_count': len(warnings),
+        'error_count': len(errors),
+        'url': VALIDATOR_URL + '?doc=' + http.quote(url),
+        'status': 'valid' if not errors else 'invalid'
+    }
+
 @hook.command
 def validate(inp):
     ".validate <url> -- runs url through w3c markup validator"
 
-    if not inp.startswith('http://'):
+    if not inp.startswith('http://') and not inp.startswith('https://'):
         inp = 'http://' + inp
 
-    url = 'http://validator.w3.org/check?uri=' + http.quote_plus(inp)
-    info = dict(http.open(url).info())
-
-    status = info['x-w3c-validator-status'].lower()
-    if status in ("valid", "invalid"):
-        errorcount = info['x-w3c-validator-errors']
-        warningcount = info['x-w3c-validator-warnings']
-        return "%s was found to be %s with %s errors and %s warnings." \
-            " see: %s" % (inp, status, errorcount, warningcount, url)
+    return (
+        "{inp} was found to be {status} with " \
+        "{error_count} error(s) and " \
+        "{warning_count} warning(s)." \
+        " see: {url}"
+    ).format(inp=inp, **get_validation_results(inp))


### PR DESCRIPTION
The old validator no longer seems to return any results,
it only returns the "Abort" value for any results, along
with a redirect.

However, the new validator no longer specifies status in
the headers, so a minor rewrite needed to occur.