### PR TITLE
simplify threads and drop @hook.singlethreaded

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -147,7 +147,14 @@ def dispatch(input, kind, func, args, autohelp=False):
             return
         input.api_key = key
 
-    bot.threads[func].put(input)
+    # There are some edge cases where we no longer will have an underlying thread
+    # at this point because of reloads occurring.  It's not likely, but given that
+    # the case would take down the bot, let's just protect against it and lose the
+    # message.
+
+    # TODO: Create a more fault tolerant way of passing messages to threads?
+    if func in bot.threads:
+        bot.threads[func].put(input)
 
 
 def match_command(command):

--- a/core/main.py
+++ b/core/main.py
@@ -79,6 +79,9 @@ class Handler(Thread):
         self._input_queue = Queue.Queue()
         self._db_connections = {}
 
+    def __del__(self):
+        self.stop()
+
     def _call_func(self, obj):
         func = self._func
         args = self._func._args

--- a/core/reload.py
+++ b/core/reload.py
@@ -103,8 +103,7 @@ def reload(init=False):
 
             for obj in namespace.itervalues():
                 if hasattr(obj, '_hook'):  # check for magic
-                    if obj._thread:
-                        bot.threads[obj] = Handler(obj)
+                    bot.threads[obj] = Handler(obj)
 
                     for type, data in obj._hook:
                         bot.plugs[type] += [data]

--- a/core/reload.py
+++ b/core/reload.py
@@ -104,6 +104,7 @@ def reload(init=False):
             for obj in namespace.itervalues():
                 if hasattr(obj, '_hook'):  # check for magic
                     bot.threads[obj] = Handler(obj)
+                    bot.threads[obj].start()
 
                     for type, data in obj._hook:
                         bot.plugs[type] += [data]

--- a/docs/Plugin-development.md
+++ b/docs/Plugin-development.md
@@ -42,11 +42,6 @@ The hook type is assigned to plugin functions using decorators found
 in `util/hook.py`.
 
 
-There is also a secondary hook decorator: `@hook.singlethread`
-
-It indicates that the function should run in its own thread. Note that, in
-that case, you can't use the existing database connection object.
-
 ### Shared arguments ###
 
 > This section has to be verified.

--- a/plugins/log.py
+++ b/plugins/log.py
@@ -81,7 +81,6 @@ def get_log_fd(dir, server, chan):
     return fd
 
 
-@hook.singlethread
 @hook.event('*')
 def log(paraml, input=None, bot=None):
     timestamp = gmtime(timestamp_format)

--- a/plugins/seen.py
+++ b/plugins/seen.py
@@ -13,7 +13,6 @@ def db_init(db):
     db.commit()
 
 
-@hook.singlethread
 @hook.event('PRIVMSG', ignorebots=False)
 def seeninput(paraml, input=None, db=None, bot=None):
     db_init(db)

--- a/plugins/tell.py
+++ b/plugins/tell.py
@@ -22,7 +22,6 @@ def get_tells(db, user_to):
                       (user_to.lower(),)).fetchall()
 
 
-@hook.singlethread
 @hook.event('PRIVMSG')
 def tellinput(paraml, input=None, db=None):
     if 'showtells' in input.msg.lower():

--- a/plugins/util/hook.py
+++ b/plugins/util/hook.py
@@ -34,9 +34,6 @@ def _hook_add(func, add, name=''):
             args.append(0)  # means kwargs present
         func._args = args
 
-    if not hasattr(func, '_thread'):  # does function run in its own thread?
-        func._thread = False
-
 
 def sieve(func):
     if func.func_code.co_argcount != 5:
@@ -78,11 +75,6 @@ def event(arg=None, **kwargs):
         if arg is not None:
             args['events'] = arg.split()
         return event_wrapper
-
-
-def singlethread(func):
-    func._thread = True
-    return func
 
 
 def api_key(key):


### PR DESCRIPTION
this makes it so all commands have their own thread, instead of spawning
endless threads that spin up and die.  This means a simplification of logic
when dealing with creating plugins and how they interact with the rest of
the bot.  this should benefit us because the bot isn't doing any sort of
management of a thread pool.