### PR TITLE
don't ignore SSL Cert validity by default

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -45,7 +45,7 @@ Optional:
 * nickserv_command: defaults to "IDENTIFY %s" (interpolated with password)
 * ssl: defaults to false. Set to true to connect to the server using SSL
 * ignore_cert: defaults to `false`. Set to `true` to disable validation of certificates
-  from servers - thus weakening the security of your conncetion.
+  from servers - thus weakening the security of your connection.
 
 
 ## Examples ##

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -44,8 +44,8 @@ Optional:
 * nickserv_name: defaults to "nickserv" (standard on most networks)
 * nickserv_command: defaults to "IDENTIFY %s" (interpolated with password)
 * ssl: defaults to false. Set to true to connect to the server using SSL
-* ignore_cert: defaults to true. Set to false to validate the certificate
-  that the remote host uses for the SSL connection.
+* ignore_cert: defaults to `false`. Set to `true` to disable validation of certificates
+  from servers - thus weakening the security of your conncetion.
 
 
 ## Examples ##


### PR DESCRIPTION
ignoring SSL certificate validity defeats much of the purpose
of using SSL certificates in the first place, so the default
should be to have that disabled