### PR TITLE
Clean up hitting the IRC internal configuration directly

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -52,6 +52,8 @@ def config():
             bot.config = json.load(open(find_config()))
             bot._config_mtime = config_mtime
             for name, conf in bot.config['connections'].iteritems():
+                conf.setdefault('censored_strings', bot.config.get('censored_strings', []))
+
                 if name in bot.conns:
                     bot.conns[name].set_conf(conf)
                 else:

--- a/core/db.py
+++ b/core/db.py
@@ -6,7 +6,7 @@ def get_db_connection(conn, name=''):
     "returns an sqlite3 connection to a persistent database"
 
     if not name:
-        name = '%s.%s.db' % (conn.nick, conn.server)
+        name = '%s.%s.db' % (conn.nick, conn.server_host)
 
     filename = os.path.join(bot.persist_dir, name)
     return sqlite3.connect(filename, timeout=10)

--- a/core/irc.py
+++ b/core/irc.py
@@ -7,6 +7,12 @@ import Queue
 from ssl import wrap_socket, CERT_NONE, CERT_REQUIRED, SSLError
 
 
+DEFAULT_NAME = 'skybot'
+DEFAULT_REALNAME = 'Python bot - http://github.com/rmmh/skybot'
+DEFAULT_NICKSERV_NAME = 'nickserv'
+DEFAULT_NICKSERV_COMMAND = 'IDENTIFY %s'
+
+
 def decode(txt):
     for codec in ('utf-8', 'iso-8859-1', 'shift_jis', 'cp1252'):
         try:
@@ -123,11 +129,6 @@ class crlf_ssl_tcp(crlf_tcp):
     def handle_receive_exception(self, error, last_timestamp):
         return crlf_tcp.handle_receive_exception(self, error, last_timestamp)
 
-irc_prefix_rem = re.compile(r'(.*?) (.*?) (.*)').match
-irc_noprefix_rem = re.compile(r'()(.*?) (.*)').match
-irc_netmask_rem = re.compile(r':?([^!@]*)!?([^@]*)@?(.*)').match
-irc_param_ref = re.compile(r'(?:^|(?<= ))(:.*|[^ ]+)').findall
-
 def zip_channels(channels):
     channels.sort(key=lambda x: ' ' not in x)  # keyed channels first
     chans = []
@@ -150,40 +151,77 @@ def test_zip_channels():
     assert zip_channels(['#a', '#b']) == ['#a,#b']
 
 class IRC(object):
+    IRC_PREFIX_REM = re.compile(r'(.*?) (.*?) (.*)').match
+    IRC_NOPROFEIX_REM = re.compile(r'()(.*?) (.*)').match
+    IRC_NETMASK_REM = re.compile(r':?([^!@]*)!?([^@]*)@?(.*)').match
+    IRC_PARAM_REF = re.compile(r'(?:^|(?<= ))(:.*|[^ ]+)').findall
 
     "handles the IRC protocol"
     # see the docs/ folder for more information on the protocol
 
     def __init__(self, conf):
         self.conn = None
-        self.set_conf(conf)
+
+        self.censored_strings = []
+
+        self.nick = DEFAULT_NAME
+        self.user = DEFAULT_NAME
+        self.realname = DEFAULT_REALNAME
+        self.user_mode = None
+
+        self.server_host = None
+        self.server_port = 6667
+        self.server_password = None
+
+        self.nickserv_password = None
+        self.nickserv_name = DEFAULT_NICKSERV_NAME
+        self.nickserv_command = DEFAULT_NICKSERV_COMMAND
+
+        self.channels = []
+        self.admins = []
 
         self.out = Queue.Queue()  # responses from the server are placed here
         # format: [rawline, prefix, command, params,
         # nick, user, host, paramlist, msg]
+
+        self.set_conf(conf)
+
         self.connect()
 
         thread.start_new_thread(self.parse_loop, ())
 
     def set_conf(self, conf):
-        self.conf = conf
-        self.nick = self.conf['nick']
-        self.server = self.conf['server']
+        self.censored_strings = conf.get('censored_strings', [])
+
+        self.nick = conf.get('nick', DEFAULT_NAME)
+        self.user = conf.get('user', DEFAULT_NAME)
+        self.realname = conf.get('realname', DEFAULT_REALNAME)
+        self.user_mode = conf.get('mode', None)
+
+        self.server_host = conf['server']
+        self.server_port = conf.get('port', 6667)
+        self.server_password = conf.get('server_password', None)
+
+        self.nickserv_password = conf.get('nickserv_password', None)
+        self.nickserv_name = conf.get('nickserv_name', DEFAULT_NICKSERV_NAME)
+        self.nickserv_command = conf.get('nickserv_command', DEFAULT_NICKSERV_COMMAND)
+
+        self.channels = conf.get('channels', [])
+        self.admins = conf.get('admins', [])
+
         if self.conn is not None:
             self.join_channels()
 
     def create_connection(self):
-        return crlf_tcp(self.server, self.conf.get('port', 6667))
+        return crlf_tcp(self.server_host, self.server_port)
 
     def connect(self):
         self.conn = self.create_connection()
         thread.start_new_thread(self.conn.run, ())
         self.cmd("NICK", [self.nick])
-        self.cmd("USER",
-                 [self.conf.get('user', 'skybot'), "3", "*", self.conf.get('realname',
-                                                                 'Python bot - http://github.com/rmmh/skybot')])
-        if 'server_password' in self.conf:
-            self.cmd("PASS", [self.conf['server_password']])
+        self.cmd("USER", [self.user, "3", "*", self.realname])
+        if self.server_password:
+            self.cmd("PASS", [self.server_password])
 
     def parse_loop(self):
         while True:
@@ -194,11 +232,11 @@ class IRC(object):
                 continue
 
             if msg.startswith(":"):  # has a prefix
-                prefix, command, params = irc_prefix_rem(msg).groups()
+                prefix, command, params = self.IRC_PREFIX_REM(msg).groups()
             else:
-                prefix, command, params = irc_noprefix_rem(msg).groups()
-            nick, user, host = irc_netmask_rem(prefix).groups()
-            paramlist = irc_param_ref(params)
+                prefix, command, params = self.IRC_NOPROFEIX_REM(msg).groups()
+            nick, user, host = self.IRC_NETMASK_REM(prefix).groups()
+            paramlist = self.IRC_PARAM_REF(params)
             lastparam = ""
             if paramlist:
                 if paramlist[-1].startswith(':'):
@@ -214,10 +252,9 @@ class IRC(object):
         self.cmd("JOIN", channel.split(" "))  # [chan, password]
 
     def join_channels(self):
-        channels = self.conf.get('channels', [])
-        if channels:
+        if self.channels:
             # TODO: send multiple join commands for large channel lists
-            self.cmd("JOIN", zip_channels(channels))
+            self.cmd("JOIN", zip_channels(self.channels))
 
     def msg(self, target, text):
         self.cmd("PRIVMSG", [target, text])
@@ -234,7 +271,6 @@ class IRC(object):
 
 
 class FakeIRC(IRC):
-
     def __init__(self, conf):
         self.set_conf(conf)
         self.out = Queue.Queue()  # responses from the server are placed here
@@ -272,6 +308,17 @@ class FakeIRC(IRC):
 
 
 class SSLIRC(IRC):
+    def __init__(self, conf):
+        super(SSLIRC, self).__init__(conf=conf)
+
+        self.server_port = 6697
+        self.server_ignore_cert = False
+
+    def set_conf(self, conf):
+        super(SSLIRC, self).set_conf(conf)
+
+        self.server_port = conf.get('port', 6697)
+        self.server_ignore_cert = conf.get('ignore_cert', False)
 
     def create_connection(self):
-        return crlf_ssl_tcp(self.server, self.conf.get('port', 6697), self.conf.get('ignore_cert', True))
+        return crlf_ssl_tcp(self.server_host, self.server_port, self.server_ignore_cert)

--- a/core/main.py
+++ b/core/main.py
@@ -11,6 +11,8 @@ class Input(dict):
     def __init__(self, conn, raw, prefix, command, params,
                  nick, user, host, paraml, msg):
 
+        server = conn.server_host
+
         chan = paraml[0].lower()
         if chan == conn.nick.lower():  # is a PM
             chan = nick
@@ -48,7 +50,7 @@ class Input(dict):
 
         dict.__init__(self, conn=conn, raw=raw, prefix=prefix, command=command,
                       params=params, nick=nick, user=user, host=host,
-                      paraml=paraml, msg=msg, server=conn.server, chan=chan,
+                      paraml=paraml, msg=msg, server=server, chan=chan,
                       notice=notice, say=say, reply=reply, pm=pm, bot=bot,
                       kick=kick, ban=ban, unban=unban, me=me,
                       set_nick=set_nick, lastparam=paraml[-1])

--- a/plugins/misc.py
+++ b/plugins/misc.py
@@ -28,7 +28,7 @@ def get_version():
 @hook.event('KICK')
 def rejoin(paraml, conn=None):
     if paraml[1] == conn.nick:
-        if paraml[0].lower() in conn.conf.get("channels", []):
+        if paraml[0].lower() in conn.channels:
             conn.join(paraml[0])
 
 
@@ -41,15 +41,15 @@ def invite(paraml, conn=None):
 @hook.event('004')
 def onjoin(paraml, conn=None):
     # identify to services
-    nickserv_password = conn.conf.get('nickserv_password', '')
-    nickserv_name = conn.conf.get('nickserv_name', 'nickserv')
-    nickserv_command = conn.conf.get('nickserv_command', 'IDENTIFY %s')
+    nickserv_password = conn.nickserv_password
+    nickserv_name = conn.nickserv_name
+    nickserv_command = conn.nickserv_command
     if nickserv_password:
         conn.msg(nickserv_name, nickserv_command % nickserv_password)
         time.sleep(1)
 
     # set mode on self
-    mode = conn.conf.get('mode')
+    mode = conn.user_mode
     if mode:
         conn.cmd('MODE', [conn.nick, mode])
 

--- a/plugins/sieve.py
+++ b/plugins/sieve.py
@@ -24,7 +24,7 @@ def sieve_suite(bot, input, func, kind, args):
         return None
 
     acls = bot.config.get('acls', {})
-    for acl in [acls.get(func.__name__), acls.get(input.chan), acls.get(input.conn.server)]:
+    for acl in [acls.get(func.__name__), acls.get(input.chan), acls.get(input.server)]:
         if acl is None:
             continue
         if 'deny-except' in acl:
@@ -45,7 +45,7 @@ def sieve_suite(bot, input, func, kind, args):
             if input.nick.lower() in acl['blacklist-nicks']:
                 return None
 
-    admins = input.conn.conf.get('admins', [])
+    admins = input.conn.admins
     input.admin = input.host in admins or input.nick in admins
 
     if args.get('adminonly', False):


### PR DESCRIPTION
the IRC connections were arbitrarily getting values from the conf,
for the connection and there was no source of truth for the default
values.  To clear things up, we're instead handling all of that within
the IRC classes themselves, and only reference the explicitly set values.

Also move some of the global regex to the IRC connection object to
clean up the global namespace