### PR TITLE
Support multiple API keys

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -150,8 +150,8 @@ def dispatch(input, kind, func, args, autohelp=False):
             input.reply('error: missing api keys - {}'.format(missing))
             return
 
-        # Return a signle key as just the value, and multiple keys as a dict.
-        if len(keys) = 1:
+        # Return a single key as just the value, and multiple keys as a dict.
+        if len(keys) == 1:
             input.api_key = keys.values()[0]
         else:
             input.api_key = keys

--- a/core/main.py
+++ b/core/main.py
@@ -143,12 +143,18 @@ def dispatch(input, kind, func, args, autohelp=False):
 
     if hasattr(func, '_apikeys'):
         bot_keys = bot.config.get('api_keys', {})
-        keys = {key: bot_keys.get(key) for key in func._apikeys}
+        if len(func._apikeys) > 1:
+            keys = {key: bot_keys.get(key) for key in func._apikeys}
 
-        missing = [keyname for keyname, value in keys.items() if value is None]
-        if missing:
-            input.reply('error: missing api keys - {}'.format(missing))
-            return
+            missing = [keyname for keyname, value in keys.items() if value is None]
+            if missing:
+                input.reply('error: missing api keys - {}'.format(missing))
+                return
+        else:
+            key = bot_keys.get(func._apikey[0], None)
+            if key is None:
+                input.reply('error: missing api key')
+                return
 
         input.api_key = keys
 

--- a/core/main.py
+++ b/core/main.py
@@ -2,7 +2,6 @@ import re
 import thread
 import traceback
 
-
 thread.stack_size(1024 * 512)  # reduce vm size
 
 
@@ -142,12 +141,16 @@ def dispatch(input, kind, func, args, autohelp=False):
         input.reply(func.__doc__)
         return
 
-    if hasattr(func, '_apikey'):
-        key = bot.config.get('api_keys', {}).get(func._apikey, None)
-        if key is None:
-            input.reply('error: missing api key')
+    if hasattr(func, '_apikeys'):
+        bot_keys = bot.config.get('api_keys', {})
+        keys = {key: bot_keys.get(key) for key in func._apikeys}
+
+        missing = [keyname for keyname, value in keys.items() if value is None]
+        if missing:
+            input.reply('error: missing api keys - {}'.format(missing))
             return
-        input.api_key = key
+
+        input.api_key = keys
 
     if func._thread:
         bot.threads[func].put(input)

--- a/core/main.py
+++ b/core/main.py
@@ -151,8 +151,8 @@ def dispatch(input, kind, func, args, autohelp=False):
                 input.reply('error: missing api keys - {}'.format(missing))
                 return
         else:
-            key = bot_keys.get(func._apikey[0], None)
-            if key is None:
+            keys = bot_keys.get(func._apikey[0], None)
+            if keys is None:
                 input.reply('error: missing api key')
                 return
 

--- a/core/main.py
+++ b/core/main.py
@@ -143,20 +143,18 @@ def dispatch(input, kind, func, args, autohelp=False):
 
     if hasattr(func, '_apikeys'):
         bot_keys = bot.config.get('api_keys', {})
-        if len(func._apikeys) > 1:
-            keys = {key: bot_keys.get(key) for key in func._apikeys}
+        keys = {key: bot_keys.get(key) for key in func._apikeys}
 
-            missing = [keyname for keyname, value in keys.items() if value is None]
-            if missing:
-                input.reply('error: missing api keys - {}'.format(missing))
-                return
+        missing = [keyname for keyname, value in keys.items() if value is None]
+        if missing:
+            input.reply('error: missing api keys - {}'.format(missing))
+            return
+
+        # Return a signle key as just the value, and multiple keys as a dict.
+        if len(keys) = 1:
+            input.api_key = keys.values()[0]
         else:
-            keys = bot_keys.get(func._apikey[0], None)
-            if keys is None:
-                input.reply('error: missing api key')
-                return
-
-        input.api_key = keys
+            input.api_key = keys
 
     if func._thread:
         bot.threads[func].put(input)

--- a/plugins/util/hook.py
+++ b/plugins/util/hook.py
@@ -85,9 +85,9 @@ def singlethread(func):
     return func
 
 
-def api_key(key):
+def api_key(*keys):
     def annotate(func):
-        func._apikey = key
+        func._apikeys = keys
         return func
     return annotate
 


### PR DESCRIPTION
This lets a hook request multiple API keys at once, say if a plugin needs to geocode a location and then get the weather for the lat/long. It gets back a dict with the API keys in it. 