### PR TITLE
docs: Fix a few typos

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -54,7 +54,7 @@ def main():
 
     while True:
         reload()  # these functions only do things
-        config()  # if changes have occured
+        config()  # if changes have occurred
 
         for conn in bot.conns.values():
             try:

--- a/core/irc.py
+++ b/core/irc.py
@@ -117,7 +117,7 @@ class crlf_tcp(object):
 
 class crlf_ssl_tcp(crlf_tcp):
 
-    "Handles ssl tcp connetions that consist of utf-8 lines ending with crlf"
+    "Handles ssl tcp connections that consist of utf-8 lines ending with crlf"
 
     def __init__(self, host, port, ignore_cert_errors, timeout=300):
         self.ignore_cert_errors = ignore_cert_errors

--- a/plugins/dotnetpad.py
+++ b/plugins/dotnetpad.py
@@ -6,7 +6,7 @@ from util import hook, http
 
 
 def dotnetpad(lang, code):
-    "Posts a provided snippet of code in a provided langugage to dotnetpad.net"
+    "Posts a provided snippet of code in a provided language to dotnetpad.net"
 
     code = code.encode("utf8")
     params = {"language": lang, "code": code}

--- a/plugins/down.py
+++ b/plugins/down.py
@@ -8,7 +8,7 @@ from util import hook, http
 def down(inp):
     """.down <url> -- checks to see if the website is down"""
 
-    # urlparse follows RFC closely, so we have to check for schema existance and prepend empty schema if necessary
+    # urlparse follows RFC closely, so we have to check for schema existence and prepend empty schema if necessary
     if not inp.startswith("//") and "://" not in inp:
         inp = "//" + inp
 


### PR DESCRIPTION
There are small typos in:
- bot.py
- core/irc.py
- plugins/dotnetpad.py
- plugins/down.py

Fixes:
- Should read `language` rather than `langugage`.
- Should read `occurred` rather than `occured`.
- Should read `existence` rather than `existance`.
- Should read `connections` rather than `connetions`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md