### PR TITLE
Make the bot python 3.11 compatible #238

### DIFF
--- a/plugins/util/hook.py
+++ b/plugins/util/hook.py
@@ -2,47 +2,47 @@ import inspect
 import re
 
 
-def _hook_add(func, add, name=""):
-    if not hasattr(func, "_hook"):
+def _hook_add(func, add, name=''):
+    if not hasattr(func, '_hook'):
         func._hook = []
     func._hook.append(add)
 
-    if not hasattr(func, "_filename"):
+    if not hasattr(func, '_filename'):
         func._filename = func.__code__.co_filename
 
-    if not hasattr(func, "_args"):
-        argspec = inspect.getargspec(func)
+    if not hasattr(func, '_args'):
+        argspec = inspect.getfullargspec(func)
         if name:
             n_args = len(argspec.args)
             if argspec.defaults:
                 n_args -= len(argspec.defaults)
-            if argspec.keywords:
+            if argspec.varkw:
                 n_args -= 1
             if argspec.varargs:
                 n_args -= 1
             if n_args != 1:
-                err = "%ss must take 1 non-keyword argument (%s)" % (
-                    name,
-                    func.__name__,
-                )
+                err = '%ss must take 1 non-keyword argument (%s)' % (name,
+                                                                     func.__name__)
                 raise ValueError(err)
 
         args = []
         if argspec.defaults:
-            end = bool(argspec.keywords) + bool(argspec.varargs)
-            args.extend(argspec.args[-len(argspec.defaults) : end if end else None])
-        if argspec.keywords:
+            end = bool(argspec.varkw) + bool(argspec.varargs)
+            args.extend(argspec.args[-len(argspec.defaults):
+                        end if end else None])
+        if argspec.varkw:
             args.append(0)  # means kwargs present
         func._args = args
 
-    if not hasattr(func, "_thread"):  # does function run in its own thread?
+    if not hasattr(func, '_thread'):  # does function run in its own thread?
         func._thread = False
 
 
 def sieve(func):
     if func.__code__.co_argcount != 5:
-        raise ValueError("sieves must take 5 arguments: (bot, input, func, type, args)")
-    _hook_add(func, ["sieve", (func,)])
+        raise ValueError(
+            'sieves must take 5 arguments: (bot, input, func, type, args)')
+    _hook_add(func, ['sieve', (func,)])
     return func
 
 
@@ -50,13 +50,13 @@ def command(arg=None, **kwargs):
     args = {}
 
     def command_wrapper(func):
-        args.setdefault("name", func.__name__)
-        _hook_add(func, ["command", (func, args)], "command")
+        args.setdefault('name', func.__name__)
+        _hook_add(func, ['command', (func, args)], 'command')
         return func
 
     if kwargs or not inspect.isfunction(arg):
         if arg is not None:
-            args["name"] = arg
+            args['name'] = arg
         args.update(kwargs)
         return command_wrapper
     else:
@@ -67,16 +67,16 @@ def event(arg=None, **kwargs):
     args = kwargs
 
     def event_wrapper(func):
-        args["name"] = func.__name__
-        args.setdefault("events", ["*"])
-        _hook_add(func, ["event", (func, args)], "event")
+        args['name'] = func.__name__
+        args.setdefault('events', ['*'])
+        _hook_add(func, ['event', (func, args)], 'event')
         return func
 
     if inspect.isfunction(arg):
         return event_wrapper(arg, kwargs)
     else:
         if arg is not None:
-            args["events"] = arg.split()
+            args['events'] = arg.split()
         return event_wrapper
 
 
@@ -89,7 +89,6 @@ def api_key(*keys):
     def annotate(func):
         func._apikeys = keys
         return func
-
     return annotate
 
 
@@ -97,10 +96,10 @@ def regex(regex, flags=0, **kwargs):
     args = kwargs
 
     def regex_wrapper(func):
-        args["name"] = func.__name__
-        args["regex"] = regex
-        args["re"] = re.compile(regex, flags)
-        _hook_add(func, ["regex", (func, args)], "regex")
+        args['name'] = func.__name__
+        args['regex'] = regex
+        args['re'] = re.compile(regex, flags)
+        _hook_add(func, ['regex', (func, args)], 'regex')
         return func
 
     if inspect.isfunction(regex):


### PR DESCRIPTION
This seems to fix the issue of running the bot on python 3.11. Have not tested all plugins yet, but most of them seem to work.

Issue: #238 